### PR TITLE
Added reverse

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,18 @@ The default behavior of a dummy switch is to turn itself off one second after be
     ]
 
 ```
+
+## Reverse Switches
+
+You may also want to create a dummy switch that turns itself on one second after being turned off. This can be done by passing the 'reverse' argument in your config.json:
+
+```
+    "accessories": [
+        {
+          "accessory": "DummySwitch",
+          "name": "My Stateful Switch 1",
+          "reverse": true
+        }   
+    ]
+
+```

--- a/index.js
+++ b/index.js
@@ -14,10 +14,13 @@ function DummySwitch(log, config) {
   this.log = log;
   this.name = config.name;
   this.stateful = config.stateful;
-
+  this.reverse = config.reverse;
+  
   this._service = new Service.Switch(this.name);
   this._service.getCharacteristic(Characteristic.On)
     .on('set', this._setOn.bind(this));
+
+  if (this.reverse) this._service.setCharacteristic(Characteristic.On, true);
 }
 
 DummySwitch.prototype.getServices = function() {
@@ -28,11 +31,14 @@ DummySwitch.prototype._setOn = function(on, callback) {
 
   this.log("Setting switch to " + on);
 
-  if (on && !this.stateful) {
+  if (on && !this.reverse && !this.stateful) {
     setTimeout(function() {
       this._service.setCharacteristic(Characteristic.On, false);
     }.bind(this), 1000);
+  } else if (!on && this.reverse && !this.stateful) {
+    setTimeout(function() {
+      this._service.setCharacteristic(Characteristic.On, true);
+    }.bind(this), 1000);
   }
-
   callback();
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-dummy",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Dummy switches for Homebridge: https://github.com/nfarina/homebridge",
   "license": "ISC",
   "keywords": [


### PR DESCRIPTION
Hi. I added the ability to keep the dummy switch in an "on" state. When turned off, it now automatically turns back on with the added config of "reverse".
My homebridge system also uses Alexa/EchoDots (via NorthernMan54's Alexa mod) so this was done to help so I could have a HomeKit scene like "All Kitchen Lights" (which turn them all off) and then tell Alexa to turn them off. Without the change, I had to tell Alexa to "turn All Kitchen Lights on" to get them to turn off... which just didn't sound right. :)
So I added the reverse and now all works and sounds better.

Thanks for the HB solution by the way! It gave me a new hobby and got me back into some programming.