### PR TITLE
Resettable timer

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -29,10 +29,10 @@
                 "description": "The switch will turn off after this number of milliseconds. Not used if the switch is stateful."
             },
             "resettable": {
-                "title": "resettable",
+                "title": "Resettable",
                 "type": "boolean",
                 "default": false,
-                "description": "Resets the timer if the switch is set to on before the timer has finished"
+                "description": "The timer will reset each time the switch is turned on. "
             }
         }
     }

--- a/config.schema.json
+++ b/config.schema.json
@@ -27,6 +27,12 @@
                 "type": "number",
                 "default": 1000,
                 "description": "The switch will turn off after this number of milliseconds. Not used if the switch is stateful."
+            },
+            "resettable": {
+                "title": "resettable",
+                "type": "boolean",
+                "default": false,
+                "description": "Resets the timer if the switch is set to on before the timer has finished"
             }
         }
     }

--- a/index.js
+++ b/index.js
@@ -16,6 +16,8 @@ function DummySwitch(log, config) {
   this.stateful = config.stateful;
   this.reverse = config.reverse;
   this.time = config.time ? config.time : 1000;		
+  this.resettable = config.resettable;
+  this.timer = null;
   this._service = new Service.Switch(this.name);
   
   this.cacheDirectory = HomebridgeAPI.user.persistPath();
@@ -46,11 +48,17 @@ DummySwitch.prototype._setOn = function(on, callback) {
   this.log("Setting switch to " + on);
 
   if (on && !this.reverse && !this.stateful) {
-    setTimeout(function() {
+    if (this.resettable) {
+      clearTimeout(this.timer);
+    }
+    this.timer = setTimeout(function() {
       this._service.setCharacteristic(Characteristic.On, false);
     }.bind(this), this.time);
   } else if (!on && this.reverse && !this.stateful) {
-    setTimeout(function() {
+    if (this.resettable) {
+      clearTimeout(this.timer);
+    }
+    this.timer = setTimeout(function() {
       this._service.setCharacteristic(Characteristic.On, true);
     }.bind(this), this.time);
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-dummy",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Dummy switches for Homebridge: https://github.com/nfarina/homebridge",
   "license": "ISC",
   "keywords": [


### PR DESCRIPTION
This PR adds a `resettable` config flag, that will reset the timer each time the switch is set to on. 

Use case: 
I want a light to turn off 60 seconds after the last detected motion. (Like #29, also solves #26)

- Create a resettable switch `Light Timer Dummy` with a timer of 60 sconds
- Create an automation for `Motion Sensor` activation switching `Light Timer Dummy` to `On`
- Create an automation for `Light Timer Dummy` switching `Off` to set `Light` to `Off`

Each time motion is detected, the timer will be reset. 
