### PR TITLE
(feature) random timed switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,23 @@ This can be done by passing the 'resettable' argument in your config.json:
     ]
 
 ```
+
+## Random Timed Switches
+
+You might want to create a switch that given a random time turns itself off.
+This can be achieved by enabling 'random'.
+Each time a non-stateful, random timed switch is triggered, the time is set to a random value between 0 and 'time' milliseconds.
+A random period within one hour is defined as follows in your config.json:
+
+```
+    "accessories": [
+        {
+          "accessory": "DummySwitch",
+          "name": "My Stateful Random Switch 1",
+          "time": 3600000,
+          "random": true
+        }
+    ]
+
+```
+

--- a/config.schema.json
+++ b/config.schema.json
@@ -28,6 +28,12 @@
                 "default": 1000,
                 "description": "The switch will turn off after this number of milliseconds. Not used if the switch is stateful."
             },
+            "random": {
+                "title": "Random",
+                "type": "boolean",
+                "default": false,
+                "description": "Randomize the time until a stateful switch turns off. Not used if the switch is stateful."
+            },
             "resettable": {
                 "title": "Resettable",
                 "type": "boolean",

--- a/config.schema.json
+++ b/config.schema.json
@@ -32,7 +32,7 @@
                 "title": "Random",
                 "type": "boolean",
                 "default": false,
-                "description": "Randomize the time until a stateful switch turns off. Not used if the switch is stateful."
+                "description": "Randomize the time until a switch turns off. Not used if the switch is stateful."
             },
             "resettable": {
                 "title": "Resettable",

--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ function DummySwitch(log, config) {
   this.time = config.time ? config.time : 1000;		
   this.resettable = config.resettable;
   this.timer = null;
+  this.random = config.random;
   this._service = new Service.Switch(this.name);
   
   this.informationService = new Service.AccessoryInformation();
@@ -52,9 +53,20 @@ DummySwitch.prototype.getServices = function() {
   return [this.informationService, this._service];
 }
 
+function randomize(time) {
+  return Math.floor(Math.random() * (time + 1));
+}
+
 DummySwitch.prototype._setOn = function(on, callback) {
 
-  this.log("Setting switch to " + on);
+  var delay = this.random ? randomize(this.time) : this.time;
+  var msg = "Setting switch to " + on
+  if (this.random && !this.stateful) {
+      if (on && !this.reverse || !on && this.reverse) {
+        msg = msg + " (random delay " + delay + "ms)"
+      }
+  }
+  this.log(msg);
 
   if (on && !this.reverse && !this.stateful) {
     if (this.resettable) {
@@ -62,14 +74,14 @@ DummySwitch.prototype._setOn = function(on, callback) {
     }
     this.timer = setTimeout(function() {
       this._service.setCharacteristic(Characteristic.On, false);
-    }.bind(this), this.time);
+    }.bind(this), delay);
   } else if (!on && this.reverse && !this.stateful) {
     if (this.resettable) {
       clearTimeout(this.timer);
     }
     this.timer = setTimeout(function() {
       this._service.setCharacteristic(Characteristic.On, true);
-    }.bind(this), this.time);
+    }.bind(this), delay);
   }
   
   if (this.stateful) {


### PR DESCRIPTION
Hi,


Thank you for the very useful plugin. Using timed/non-stateful switches now in automations regularly, I found a randomized timer is very helpful, too. With this PR I implemented a simple switch in the options to **allow random delays for non-stateful switches**.

Figure with the review of the settings in homebridge UI for a random timing enabled switch:
<img width="668" alt="image" src="https://user-images.githubusercontent.com/3781869/156081108-a70cff5d-751b-450c-938a-79a01d63ab80.png">

Figure with the preview of the log entry in homebridge UI when a randomized delay is enabled:
<img width="684" alt="image" src="https://user-images.githubusercontent.com/3781869/156080491-fb00fece-6517-4d7d-a9cd-92af7bd22071.png">

I hope you find this feature helpful and merge it into any upcoming release.


Thanks,
Sven

