### PR TITLE
Add support for a dimmer/brightness option; including documentation. …

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,21 @@ The default behavior of a dummy switch is to turn itself off one second after be
 
 ```
 
+## Dimmer Switches
+
+By default, switches are toggle switches (on/off). You can configure your switch to be a dimmer switch, instead, storing a brightness value between 0 and 100. This can be done by passing the 'dimmer' argument in your config.json:
+
+```
+    "accessories": [
+        {
+          "accessory": "DummySwitch",
+          "name": "My Stateful Switch 1",
+          "dimmer": true
+        }
+    ]
+
+```
+
 ## Reverse Switches
 
 You may also want to create a dummy switch that turns itself on one second after being turned off. This can be done by passing the 'reverse' argument in your config.json:

--- a/config.schema.json
+++ b/config.schema.json
@@ -16,6 +16,12 @@
                 "default": false,
                 "description": "The switch remains on instead of being automatically turned off."
             },
+            "dimmer": {
+                "title": "Dimmer",
+                "type": "boolean",
+                "default": false,
+                "description": "Make the switch a dimmer instead of a toggle (on/off) switch"
+            },
             "reverse": {
                 "title": "Reverse",
                 "type": "boolean",
@@ -39,6 +45,14 @@
                 "type": "boolean",
                 "default": false,
                 "description": "The timer will reset each time the switch is turned on. "
+            },
+            "brightness": {
+                "title": "Brightness",
+                "type": "integer",
+                "default": 0,
+                "placeholder": 0,
+                "maximum": 100,
+                "description": "Starting brightness (dimmer only)"
             },
             "disableLogging": {
                 "title": "DisableLogging",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-dummy",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Dummy switches for Homebridge: https://github.com/nfarina/homebridge",
   "license": "ISC",
   "keywords": [


### PR DESCRIPTION
I was thinking about this back in October, and finally got off my ass and did it tonight :) (This time I opted to set up an actual HB install on my desktop, instead of hand-editing files on my Synology docker container..)

I did my best to emulate your style where possible! I'm no HB guru, and happy to receive criticism. If this needs to be a separate plugin, that's fine, but I'm hoping this is a managable addition!

In short, I needed to add "Dimmer" and "Brightness" configuration options. "Dimmer" allows the user to make a dimmer instead of an on/off switch by using a Lightbulb Service; this allows storing values from 0 to 100 as the bulb's brightness. "Brightness" is simply a starting, default value; I wish I knew how to hide it from the config; I tried keywords like "hidden", but to no avail.

Because the brightness setting callback is an _additional_ callback (only created when a dimmer is being used), it piggybacks off the existing _setOn(). Effectively, a dimmer (technically Lightbulb) has all the properties and callbacks of the normal dummy switch, but it also calls the _setBrightness() callback in order to set/store the brightness. Thus, if you set stateful = false, the dimmer will go back to 0% after the delay period; random delays still work, etc.

Cheers!
J