### PR TITLE
Add explicit Homebridge 2.0 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "url": "http://github.com/nfarina/homebridge-dummy/issues"
   },
   "engines": {
-    "node": ">=0.12.0",
-    "homebridge": ">=0.2.0"
+    "node": "^18 || ^20 || ^22",
+    "homebridge": ">=1.4.0 || ^2.0.0-beta.0"
   },
   "dependencies": {
     "node-persist": "^2.1.0"


### PR DESCRIPTION
This adds explicit Homebridge 2.0 compatibility, as described [here](https://github.com/homebridge/homebridge/wiki/Updating-To-Homebridge-v2.0#for-plugin-developers).

No code changes seem to be necessary (according to the breaking changes that are mentioned in the guide) and the plugin has been successfully tested with the Homebridge 2.0 beta both by myself and [another user](https://github.com/nfarina/homebridge-dummy/issues/91#issuecomment-2571407617).

Both the supported Homebrew and Node.js versions have been updated to mirror the ones from the popular [Ring plugin](https://github.com/dgreif/ring/tree/main/packages/homebridge-ring).

Closes #91.