### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Build and Lint
 
 on: [push, pull_request]


### PR DESCRIPTION
Potential fix for [https://github.com/mpatfield/homebridge-dummy/security/code-scanning/1](https://github.com/mpatfield/homebridge-dummy/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow only checks out code, installs dependencies, lints, and builds, it only needs read access to repository contents. The best way to fix this is to add `permissions: contents: read` at the top level of the workflow (just after the `name` and before `on`), so it applies to all jobs. No other permissions are needed, and no changes to the steps or jobs are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
