### PR TITLE
Add user option to send notification when accessory resets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to homebridge-dummy will be documented in this file.
 
-## 2.0.0-beta.1 ()
+## 2.0.0-beta.3 ()
 
 ### ‼️ WARNING ‼️ — If upgrading from v0.9.2 or earlier, [READ THIS FIRST](https://github.com/mpatfield/homebridge-dummy/wiki/Migration).
 
@@ -13,6 +13,8 @@ All notable changes to homebridge-dummy will be documented in this file.
     - ⚠️ Enabling Matter on an existing Homebridge Dummy accessory will require you to reconfigure any scenes or automations for that accessory
 - [Pushover](https://pushover.net/) option for [Push Notifications](https://github.com/mpatfield/homebridge-dummy/wiki/Push-Notification#pushover)
     - ⚠️ We share a limited number of monthly notifications across all Dummy users, so please don't overuse this!
+- Added option for [Push Notification](https://github.com/mpatfield/homebridge-dummy/wiki/Push-Notification) on accessory reset with its own title/message (Thanks, [@dkerr64](https://github.com/sponsors/dkerr64)!)
+    - You may receive a push notification for accessory trigger, reset, or both
 
 ### Notes
 - The major version update from v1 to v2 reflects the significant code restructuring needed to support Matter. There should be no breaking changes for existing configurations, but please [open a ticket](https://github.com/mpatfield/homebridge-dummy/issues/new/choose) if you have any issues.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,9 @@ All notable changes to homebridge-dummy will be documented in this file.
 - [Matter Support](https://github.com/mpatfield/homebridge-dummy/wiki/Matter-Support) (Beta) for `Switch`, `Outlet`, and `Lightbulb`
     - ⚠️ Enabling Matter on an existing Homebridge Dummy accessory will require you to reconfigure any scenes or automations for that accessory
 - [Pushover](https://pushover.net/) option for [Push Notifications](https://github.com/mpatfield/homebridge-dummy/wiki/Push-Notification#pushover)
-    - ⚠️ We share a limited number of monthly notifications across all Dummy users, so please don't overuse this!
+    - ⚠️ Monthly limits are shared across all Dummy users who don't provide an `App Token` — please be considerate!
 - Added option for [Push Notification](https://github.com/mpatfield/homebridge-dummy/wiki/Push-Notification) on accessory reset with its own title/message (Thanks, [@dkerr64](https://github.com/sponsors/dkerr64)!)
-    - You may receive a push notification for accessory trigger, reset, or both
+    - You can setup push notifications for when an accessory is triggered, reset, or both
 
 ### Notes
 - The major version update from v1 to v2 reflects the significant code restructuring needed to support Matter. There should be no breaking changes for existing configurations, but please [open a ticket](https://github.com/mpatfield/homebridge-dummy/issues/new/choose) if you have any issues.

--- a/config.schema.template.json
+++ b/config.schema.template.json
@@ -47,23 +47,21 @@
           },
           "title": {
             "type": "string",
-            "title": "${config.title.pushTitle}"
+            "title": "${config.title.pushTriggerTitle}"
           },
           "text": {
             "type": "string",
-            "title": "${config.title.pushText}"
-          },
-          "onReset": {
-            "type": "boolean",
-            "title": "${config.title.onReset}"
+            "title": "${config.title.pushTriggerText}",
+            "description": "${config.description.pushTrigger}"
           },
           "resetTitle": {
             "type": "string",
-            "title": "${config.title.pushTitle}"
+            "title": "${config.title.pushResetTitle}"
           },
           "resetText": {
             "type": "string",
-            "title": "${config.title.pushText}"
+            "title": "${config.title.pushResetText}",
+            "description": "${config.description.pushReset}"
           },
           "groupType": {
             "type": "string"
@@ -83,7 +81,7 @@
               "required": ["api"]
             },
             "then": {
-              "required": ["token", "id", "text"]
+              "required": ["token", "id"]
             }
           },
           {
@@ -96,22 +94,7 @@
               "required": ["api"]
             },
             "then": {
-              "required": ["token", "text"]
-            }
-          },
-          {
-            "if": {
-              "properties": {
-                "api": {
-                  "enum": ["PINGIE_NOTIFY"]
-                },
-                "token": {
-                }
-              },
-              "required": ["api", "token"]
-            },
-            "then": {
-              "required": ["api", "id", "text"]
+              "required": ["token"]
             }
           },
           {
@@ -136,6 +119,44 @@
             },
             "then": {
               "required": ["text"]
+            }
+          },
+          {
+            "if": {
+              "properties": {
+                "title": {
+                }
+              },
+              "required": ["resetTitle"]
+            },
+            "then": {
+              "required": ["resetText"]
+            }
+          }
+        ],
+        "anyOf": [
+          {
+            "if": {
+              "properties": {
+                "token": {
+                }
+              },
+              "required": ["token"]
+            },
+            "then": {
+              "required": ["text"]
+            }
+          },
+          {
+            "if": {
+              "properties": {
+                "token": {
+                }
+              },
+              "required": ["token"]
+            },
+            "then": {
+              "required": ["resetText"]
             }
           }
         ]
@@ -1232,21 +1253,6 @@
                       "notitle": true,
                       "condition": {
                         "functionBody": "return model.accessories?.[arguments[1]]?.notification?.token || model.accessories?.[arguments[1]]?.notification?.id;"
-                      },
-                      "items": [
-                        {
-                          "key": "accessories[].notification.onReset",
-                          "flex": "0 0 auto"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "div",
-                      "displayFlex": true,
-                      "flex-direction": "row",
-                      "notitle": true,
-                      "condition": {
-                        "functionBody": "return model.accessories?.[arguments[1]]?.notification?.onReset && (model.accessories?.[arguments[1]]?.notification?.token || model.accessories?.[arguments[1]]?.notification?.id);"
                       },
                       "items": [
                         {

--- a/config.schema.template.json
+++ b/config.schema.template.json
@@ -53,6 +53,18 @@
             "type": "string",
             "title": "${config.title.pushText}"
           },
+          "onReset": {
+            "type": "boolean",
+            "title": "${config.title.onReset}"
+          },
+          "resetTitle": {
+            "type": "string",
+            "title": "${config.title.pushTitle}"
+          },
+          "resetText": {
+            "type": "string",
+            "title": "${config.title.pushText}"
+          },
           "groupType": {
             "type": "string"
           },
@@ -1209,6 +1221,40 @@
                         },
                         {
                           "key": "accessories[].notification.text",
+                          "flex": "0 0 70%"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "div",
+                      "displayFlex": true,
+                      "flex-direction": "row",
+                      "notitle": true,
+                      "condition": {
+                        "functionBody": "return model.accessories?.[arguments[1]]?.notification?.token || model.accessories?.[arguments[1]]?.notification?.id;"
+                      },
+                      "items": [
+                        {
+                          "key": "accessories[].notification.onReset",
+                          "flex": "0 0 auto"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "div",
+                      "displayFlex": true,
+                      "flex-direction": "row",
+                      "notitle": true,
+                      "condition": {
+                        "functionBody": "return model.accessories?.[arguments[1]]?.notification?.onReset && (model.accessories?.[arguments[1]]?.notification?.token || model.accessories?.[arguments[1]]?.notification?.id);"
+                      },
+                      "items": [
+                        {
+                          "key": "accessories[].notification.resetTitle",
+                          "flex": "0 0 30%"
+                        },
+                        {
+                          "key": "accessories[].notification.resetText",
                           "flex": "0 0 70%"
                         }
                       ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-dummy",
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-dummy",
-      "version": "2.0.0-beta.3",
+      "version": "2.0.0-beta.4",
       "funding": [
         {
           "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebridge-dummy",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebridge-dummy",
-      "version": "2.0.0-beta.2",
+      "version": "2.0.0-beta.3",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "displayName": "Dummy",
   "description": "Create accessories to help with HomeKit automation and control — scheduling, delays, sensors, commands, conditions, webhooks, and more",
   "type": "module",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0-beta.3",
   "homepage": "https://github.com/mpatfield/homebridge-dummy#readme",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "displayName": "Dummy",
   "description": "Create accessories to help with HomeKit automation and control — scheduling, delays, sensors, commands, conditions, webhooks, and more",
   "type": "module",
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "homepage": "https://github.com/mpatfield/homebridge-dummy#readme",
   "repository": {
     "type": "git",

--- a/src/accessory/base.ts
+++ b/src/accessory/base.ts
@@ -343,6 +343,9 @@ export abstract class DummyAccessory<C extends DummyConfig> implements MatterAcc
     this._schedule?.startTimeout();
     this._autoReset?.cancel();
     this._limiter?.cancel();
+    if (this.config?.notification?.onReset) {
+      this._notification?.notify(true);
+    }
   }
 
   protected async executeCommand(command: string): Promise<string | undefined> {

--- a/src/accessory/base.ts
+++ b/src/accessory/base.ts
@@ -13,7 +13,7 @@ import { AccessoryState, Protocol, TimeUnits } from '../model/enums.js';
 import { CharacteristicKey, HomeKitType } from '../model/homekit.js';
 import { History, HistoryEntry, HistoryType } from '../model/history.js';
 import { MATTER_SERIAL_MAX_LEN, MatterClusterKey, MatterType, MatterValue, MatterValueKey } from '../model/matter.js';
-import { NotificationManager } from '../model/notification.js';
+import { NotificationManager, NotificationType } from '../model/notification.js';
 import { CharacteristicType, DummyConfig, HomeKitAccessory, ServiceType } from '../model/types.js';
 import { Webhook } from '../model/webhook.js';
 
@@ -330,7 +330,7 @@ export abstract class DummyAccessory<C extends DummyConfig> implements MatterAcc
     }
 
     if (stateChanged) {
-      this._notification?.notify();
+      this._notification?.notify(NotificationType.TRIGGER);
     }
 
     this._limiter?.start(this.reset.bind(this));
@@ -339,12 +339,13 @@ export abstract class DummyAccessory<C extends DummyConfig> implements MatterAcc
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   protected onTimerStarted(_delay: number) {}
 
-  protected onReset() {
+  protected onReset(stateChanged: boolean = true) {
     this._schedule?.startTimeout();
     this._autoReset?.cancel();
     this._limiter?.cancel();
-    if (this.config?.notification?.onReset) {
-      this._notification?.notify(true);
+
+    if (stateChanged) {
+      this._notification?.notify(NotificationType.RESET);
     }
   }
 

--- a/src/accessory/climate/humidifier.ts
+++ b/src/accessory/climate/humidifier.ts
@@ -185,7 +185,7 @@ export class HumidifierAccessory extends DummyAccessory<HumidifierConfig> {
     if (this.state !== this.defaultState) {
       this.onTriggered(stateChanged);
     } else {
-      this.onReset();
+      this.onReset(stateChanged);
     }
 
     this.service.updateCharacteristic(this.Characteristic.CurrentHumidifierDehumidifierState, this.currentState);

--- a/src/accessory/lock.ts
+++ b/src/accessory/lock.ts
@@ -107,7 +107,7 @@ export class LockAccessory extends DummyAccessory<LockConfig> {
     if (this.state !== this.defaultLockState) {
       this.onTriggered(stateChanged);
     } else {
-      this.onReset();
+      this.onReset(stateChanged);
     }
 
     this.service.updateCharacteristic(this.Characteristic.LockTargetState, this.state);

--- a/src/accessory/onoff/lightbulb.ts
+++ b/src/accessory/onoff/lightbulb.ts
@@ -256,9 +256,9 @@ export class LightbulbAccessory extends OnOffAccessory<LightbulbConfig> {
     });
   }
 
-  override onReset() {
+  override onReset(stateChanged: boolean) {
     this.fader?.cancel();
-    super.onReset();
+    super.onReset(stateChanged);
   }
 
   override teardown(): void {

--- a/src/accessory/onoff/onoff.ts
+++ b/src/accessory/onoff/onoff.ts
@@ -122,7 +122,7 @@ export abstract class OnOffAccessory<C extends OnOffConfig = OnOffConfig> extend
     if (this.on !== this.defaultState) {
       this.onTriggered(stateChanged);
     } else {
-      this.onReset();
+      this.onReset(stateChanged);
     }
 
     this.bifurcate(

--- a/src/accessory/position/position.ts
+++ b/src/accessory/position/position.ts
@@ -173,7 +173,7 @@ export abstract class PositionAccessory<C extends PositionConfig = PositionConfi
     if (this.targetPosition !== this.defaultPosition) {
       this.onTriggered(stateChanged);
     } else {
-      this.onReset();
+      this.onReset(stateChanged);
     }
 
     this.service.updateCharacteristic(this.targetCharacteristic, this.targetPosition);

--- a/src/accessory/valve.ts
+++ b/src/accessory/valve.ts
@@ -194,7 +194,7 @@ export class ValveAccessory extends DummyAccessory<ValveConfig> {
       this.onTriggered(stateChanged);
     } else {
       this.timerExpiration = undefined;
-      this.onReset();
+      this.onReset(stateChanged);
     }
 
     this.service.updateCharacteristic(this.Characteristic.Active, this.state);

--- a/src/i18n/el.ts
+++ b/src/i18n/el.ts
@@ -199,8 +199,6 @@ const el = {
       pingieToken: 'Token',
       pingInterval: 'Διάστημα',
       preset: 'Προεπιλογή',
-      pushText: 'Κείμενο',
-      pushTitle: 'Τίτλος (Προαιρετικό)',
       random: 'Τυχαία επιλογή',
       resetOnRestart: 'Επαναφορά κατά την Επανεκκίνηση',
       schedule: 'Πρόγραμμα',

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -203,6 +203,7 @@ const en = {
       name: 'Name',
       notification: 'Notification',
       offset: 'Offset',
+      onReset: 'Also receive a notification when accessory is reset to its default value',
       operator: 'Trigger when…',
       pattern: 'Search String or RegEx',
       period: 'Per',

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -67,6 +67,8 @@ const en = {
       fadeOut: 'Reduce brightness over a fixed duration, or decrease by 1% incrementally per each time duration',
       limiter: 'Restrict the total time this accessory can be set to its non-default value, for each specified period',
       notification: 'Receive a notification when accessory is set to its opposite (non-default) value. See wiki for help.',
+      pushReset: 'When accessory returns to its default value',
+      pushTrigger: 'When accessory is set to its opposite (non-default) value',
       random: 'Time will be randomized with the above value as a maximum',
       schedule: 'Sets the accessory to its opposite (non-default) value',
     },
@@ -203,7 +205,6 @@ const en = {
       name: 'Name',
       notification: 'Notification',
       offset: 'Offset',
-      onReset: 'Also receive a notification when accessory is reset to its default value',
       operator: 'Trigger when…',
       pattern: 'Search String or RegEx',
       period: 'Per',
@@ -215,8 +216,10 @@ const en = {
       protocol: 'Protocol',
       pushoverID: 'App Token (optional)',
       pushoverToken: 'User Key',
-      pushText: 'Text',
-      pushTitle: 'Title (Optional)',
+      pushResetText: 'Reset Text',
+      pushResetTitle: 'Reset Title (Optional)',
+      pushTriggerText: 'Trigger Text',
+      pushTriggerTitle: 'Trigger Title (Optional)',
       preset: 'Preset',
       random: 'Randomize',
       resetOnRestart: 'Reset on Restart',
@@ -278,6 +281,7 @@ const en = {
 
   notification: {
     badAPI: '%s has invalid api %s. Must be one of: %s', // accessory name, input, list of APIs
+    missingText: '%s must have at least one of:  %s', // accessory name, list of required fields
     pushError: '%s was unable to send push notification', // accessory name
     pushSuccess: '%s sent a push notification', // accessory name
   },

--- a/src/i18n/missing/de.ts
+++ b/src/i18n/missing/de.ts
@@ -59,6 +59,8 @@ const de = {
       conditions: 'Set the accessory to its opposite (non-default) value when the specified conditions are met',
       fadeOut: 'Reduce brightness over a fixed duration, or decrease by 1% incrementally per each time duration',
       notification: 'Receive a notification when accessory is set to its opposite (non-default) value. See wiki for help.',
+      pushReset: 'When accessory returns to its default value',
+      pushTrigger: 'When accessory is set to its opposite (non-default) value',
     },
 
     enumNames: {
@@ -123,7 +125,6 @@ const de = {
       minimumTemperature: 'Min Temperature',
       notification: 'Notification',
       offset: 'Offset',
-      onReset: 'Also receive a notification when accessory is reset to its default value',
       operator: 'Trigger when…',
       pattern: 'Search String or RegEx',
       pingAvailability: 'State',
@@ -134,8 +135,10 @@ const de = {
       protocol: 'Protocol',
       pushoverID: 'App Token (optional)',
       pushoverToken: 'User Key',
-      pushText: 'Text',
-      pushTitle: 'Title (Optional)',
+      pushResetText: 'Reset Text',
+      pushResetTitle: 'Reset Title (Optional)',
+      pushTriggerText: 'Trigger Text',
+      pushTriggerTitle: 'Trigger Title (Optional)',
       sensorBehavior: 'Sensor Behavior',
       simulateOpenClose: 'Simulate Open/Close',
       syncSchedule: 'Sync Schedule',
@@ -170,6 +173,7 @@ const de = {
 
   notification: {
     badAPI: '%s has invalid api %s. Must be one of: %s', // accessory name, input, list of APIs
+    missingText: '%s must have at least one of:  %s', // accessory name, list of required fields
     pushError: '%s was unable to send push notification', // accessory name
     pushSuccess: '%s sent a push notification', // accessory name
   },

--- a/src/i18n/missing/de.ts
+++ b/src/i18n/missing/de.ts
@@ -123,6 +123,7 @@ const de = {
       minimumTemperature: 'Min Temperature',
       notification: 'Notification',
       offset: 'Offset',
+      onReset: 'Also receive a notification when accessory is reset to its default value',
       operator: 'Trigger when…',
       pattern: 'Search String or RegEx',
       pingAvailability: 'State',

--- a/src/i18n/missing/el.ts
+++ b/src/i18n/missing/el.ts
@@ -13,6 +13,11 @@ const el = {
 
   config: {
 
+    description: {
+      pushReset: 'When accessory returns to its default value',
+      pushTrigger: 'When accessory is set to its opposite (non-default) value',
+    },
+
     enumNames: {
       homekit: 'HomeKit (Default)',
       matter: 'Matter (Beta)',
@@ -23,14 +28,21 @@ const el = {
 
     title: {
       commandSync: 'Sync Command',
-      onReset: 'Also receive a notification when accessory is reset to its default value',
       protocol: 'Protocol',
       pushoverID: 'App Token (optional)',
       pushoverToken: 'User Key',
+      pushResetText: 'Reset Text',
+      pushResetTitle: 'Reset Title (Optional)',
+      pushTriggerText: 'Trigger Text',
+      pushTriggerTitle: 'Trigger Title (Optional)',
       sensorBehavior: 'Sensor Behavior',
       syncSchedule: 'Sync Schedule',
     },
 
+  },
+
+  notification: {
+    missingText: '%s must have at least one of:  %s', // accessory name, list of required fields
   },
 
   sensor: {

--- a/src/i18n/missing/el.ts
+++ b/src/i18n/missing/el.ts
@@ -23,6 +23,7 @@ const el = {
 
     title: {
       commandSync: 'Sync Command',
+      onReset: 'Also receive a notification when accessory is reset to its default value',
       protocol: 'Protocol',
       pushoverID: 'App Token (optional)',
       pushoverToken: 'User Key',

--- a/src/i18n/missing/es.ts
+++ b/src/i18n/missing/es.ts
@@ -123,6 +123,7 @@ const es = {
       minimumTemperature: 'Min Temperature',
       notification: 'Notification',
       offset: 'Offset',
+      onReset: 'Also receive a notification when accessory is reset to its default value',
       operator: 'Trigger when…',
       pattern: 'Search String or RegEx',
       pingAvailability: 'State',

--- a/src/i18n/missing/es.ts
+++ b/src/i18n/missing/es.ts
@@ -59,6 +59,8 @@ const es = {
       conditions: 'Set the accessory to its opposite (non-default) value when the specified conditions are met',
       fadeOut: 'Reduce brightness over a fixed duration, or decrease by 1% incrementally per each time duration',
       notification: 'Receive a notification when accessory is set to its opposite (non-default) value. See wiki for help.',
+      pushReset: 'When accessory returns to its default value',
+      pushTrigger: 'When accessory is set to its opposite (non-default) value',
     },
 
     enumNames: {
@@ -123,7 +125,6 @@ const es = {
       minimumTemperature: 'Min Temperature',
       notification: 'Notification',
       offset: 'Offset',
-      onReset: 'Also receive a notification when accessory is reset to its default value',
       operator: 'Trigger when…',
       pattern: 'Search String or RegEx',
       pingAvailability: 'State',
@@ -134,8 +135,10 @@ const es = {
       protocol: 'Protocol',
       pushoverID: 'App Token (optional)',
       pushoverToken: 'User Key',
-      pushText: 'Text',
-      pushTitle: 'Title (Optional)',
+      pushResetText: 'Reset Text',
+      pushResetTitle: 'Reset Title (Optional)',
+      pushTriggerText: 'Trigger Text',
+      pushTriggerTitle: 'Trigger Title (Optional)',
       sensorBehavior: 'Sensor Behavior',
       simulateOpenClose: 'Simulate Open/Close',
       syncSchedule: 'Sync Schedule',
@@ -170,6 +173,7 @@ const es = {
 
   notification: {
     badAPI: '%s has invalid api %s. Must be one of: %s', // accessory name, input, list of APIs
+    missingText: '%s must have at least one of:  %s', // accessory name, list of required fields
     pushError: '%s was unable to send push notification', // accessory name
     pushSuccess: '%s sent a push notification', // accessory name
   },

--- a/src/i18n/missing/ru.ts
+++ b/src/i18n/missing/ru.ts
@@ -23,6 +23,7 @@ const ru = {
 
     title: {
       commandSync: 'Sync Command',
+      onReset: 'Also receive a notification when accessory is reset to its default value',
       protocol: 'Protocol',
       pushoverID: 'App Token (optional)',
       pushoverToken: 'User Key',

--- a/src/i18n/missing/ru.ts
+++ b/src/i18n/missing/ru.ts
@@ -13,6 +13,11 @@ const ru = {
 
   config: {
 
+    description: {
+      pushReset: 'When accessory returns to its default value',
+      pushTrigger: 'When accessory is set to its opposite (non-default) value',
+    },
+
     enumNames: {
       homekit: 'HomeKit (Default)',
       matter: 'Matter (Beta)',
@@ -23,14 +28,21 @@ const ru = {
 
     title: {
       commandSync: 'Sync Command',
-      onReset: 'Also receive a notification when accessory is reset to its default value',
       protocol: 'Protocol',
       pushoverID: 'App Token (optional)',
       pushoverToken: 'User Key',
+      pushResetText: 'Reset Text',
+      pushResetTitle: 'Reset Title (Optional)',
+      pushTriggerText: 'Trigger Text',
+      pushTriggerTitle: 'Trigger Title (Optional)',
       sensorBehavior: 'Sensor Behavior',
       syncSchedule: 'Sync Schedule',
     },
 
+  },
+
+  notification: {
+    missingText: '%s must have at least one of:  %s', // accessory name, list of required fields
   },
 
   sensor: {

--- a/src/i18n/missing/vi.ts
+++ b/src/i18n/missing/vi.ts
@@ -21,6 +21,7 @@ const vi = {
 
     title: {
       commandSync: 'Sync Command',
+      onReset: 'Also receive a notification when accessory is reset to its default value',
       protocol: 'Protocol',
       pushoverID: 'App Token (optional)',
       pushoverToken: 'User Key',

--- a/src/i18n/missing/vi.ts
+++ b/src/i18n/missing/vi.ts
@@ -13,6 +13,11 @@ const vi = {
 
   config: {
 
+    description: {
+      pushReset: 'When accessory returns to its default value',
+      pushTrigger: 'When accessory is set to its opposite (non-default) value',
+    },
+
     enumNames: {
       homekit: 'HomeKit (Default)',
       matter: 'Matter (Beta)',
@@ -21,13 +26,20 @@ const vi = {
 
     title: {
       commandSync: 'Sync Command',
-      onReset: 'Also receive a notification when accessory is reset to its default value',
       protocol: 'Protocol',
       pushoverID: 'App Token (optional)',
       pushoverToken: 'User Key',
+      pushResetText: 'Reset Text',
+      pushResetTitle: 'Reset Title (Optional)',
+      pushTriggerText: 'Trigger Text',
+      pushTriggerTitle: 'Trigger Title (Optional)',
       syncSchedule: 'Sync Schedule',
     },
 
+  },
+
+  notification: {
+    missingText: '%s must have at least one of:  %s', // accessory name, list of required fields
   },
 
   startup: {

--- a/src/i18n/ru.ts
+++ b/src/i18n/ru.ts
@@ -199,8 +199,6 @@ const ru = {
       pingieToken: 'Токен',
       pingInterval: 'Интервал',
       preset: 'Предустановка',
-      pushText: 'Текст',
-      pushTitle: 'Заголовок (необязательно)',
       random: 'Случайность',
       resetOnRestart: 'Сброс при перезапуске',
       schedule: 'Расписание',

--- a/src/i18n/vi.ts
+++ b/src/i18n/vi.ts
@@ -201,8 +201,6 @@ const vi = {
       pingieToken: 'Token',
       pingInterval: 'Khoảng thời gian',
       preset: 'Cài đặt sẵn',
-      pushText: 'Nội dung',
-      pushTitle: 'Tiêu đề (Tùy chọn)',
       random: 'Ngẫu nhiên',
       resetOnRestart: 'Đặt lại khi khởi động lại',
       schedule: 'Lịch',

--- a/src/model/notification.ts
+++ b/src/model/notification.ts
@@ -47,7 +47,7 @@ export class NotificationManager {
       break;
     }
 
-    if (notification.text === undefined && notification.resetText === undefined) {
+    if (!notification.text?.trim().length && !notification.resetText?.trim().length) {
       dependency.log.warning(strings.notification.missingText, dependency.caller, '\'text\', \'resetText\'');
       valid = false;
     }

--- a/src/model/notification.ts
+++ b/src/model/notification.ts
@@ -51,26 +51,26 @@ export class NotificationManager {
 
   private constructor(private readonly dependency: DummyAddonDependency, private readonly notification: Notification) {}
 
-  public async notify(): Promise<void> {
+  public async notify(resetting: boolean = false): Promise<void> {
 
     switch (this.notification.api) {
     case NotificationAPI.PINGIE_NOTIFY:
-      await this.pingieNotify();
+      await this.pingieNotify(resetting);
       break;
     case NotificationAPI.PUSHOVER:
-      await this.pushover();
+      await this.pushover(resetting);
       break;
     }
   }
 
-  private async pingieNotify() {
+  private async pingieNotify(resetting: boolean) {
     try {
 
       const endpoint = `https://notifypush.pingie.com/notify-json/${this.notification.id}`;
 
       const payload: Record<string, string | undefined> = {
-        text: this.notification.text,
-        title: this.notification.title,
+        text: (resetting && this.notification?.onReset) ? this.notification.resetText : this.notification.text,
+        title: (resetting && this.notification?.onReset) ? this.notification.resetTitle : this.notification.title,
         groupType: this.notification.groupType,
         iconUrl: this.notification.iconURL ?? DEFAULT_PUSH_ICON_URL,
       };
@@ -100,7 +100,7 @@ export class NotificationManager {
     }
   }
 
-  private async pushover() {
+  private async pushover(resetting: boolean) {
 
     const key = Buffer.from(PLUGIN_NAME, 'utf8');
     const bytes = [...P2, ...P3, ...P1];
@@ -113,8 +113,8 @@ export class NotificationManager {
       const params: Record<string, string | undefined> = {
         token,
         user: this.notification.token,
-        message: this.notification.text,
-        title: this.notification.title,
+        message: (resetting && this.notification?.onReset) ? this.notification.resetText : this.notification.text,
+        title: (resetting && this.notification?.onReset) ? this.notification.resetTitle : this.notification.title,
       };
 
       const response = await axios.post(endpoint, undefined,

--- a/src/model/notification.ts
+++ b/src/model/notification.ts
@@ -19,6 +19,11 @@ const P3 = [0x59, 0x05, 0x1A, 0x1A, 0x18, 0x08, 0x1F, 0x0C, 0x1E, 0x02];
 
 const AXIOS_TIMEOUT = 10000;
 
+export enum NotificationType {
+  TRIGGER,
+  RESET
+}
+
 export class NotificationManager {
 
   public static new(dependency: DummyAddonDependency, notification?: Notification): NotificationManager | undefined {
@@ -28,18 +33,23 @@ export class NotificationManager {
     }
 
     if (!isValid(NotificationAPI, notification.api)) {
-      dependency.log.warning(strings.notification.badAPI, this.name, `'${notification.api}'`, printableValues(NotificationAPI));
+      dependency.log.warning(strings.notification.badAPI, dependency.caller, `'${notification.api}'`, printableValues(NotificationAPI));
       return;
     }
 
     let valid: boolean;
     switch (notification.api) {
     case NotificationAPI.PINGIE_NOTIFY:
-      valid = assert(dependency.log, dependency.caller, notification, 'token', 'id', 'text');
+      valid = assert(dependency.log, dependency.caller, notification, 'token', 'id');
       break;
     case NotificationAPI.PUSHOVER:
-      valid = assert(dependency.log, dependency.caller, notification, 'token', 'text');
+      valid = assert(dependency.log, dependency.caller, notification, 'token');
       break;
+    }
+
+    if (notification.text === undefined && notification.resetText === undefined) {
+      dependency.log.warning(strings.notification.missingText, dependency.caller, '\'text\', \'resetText\'');
+      valid = false;
     }
 
     if (!valid) {
@@ -51,26 +61,31 @@ export class NotificationManager {
 
   private constructor(private readonly dependency: DummyAddonDependency, private readonly notification: Notification) {}
 
-  public async notify(resetting: boolean = false): Promise<void> {
+  public async notify(type: NotificationType): Promise<void> {
+
+    if ( (type === NotificationType.TRIGGER && this.notification.text === undefined)
+      || (type === NotificationType.RESET && this.notification.resetText === undefined)) {
+      return;
+    }
 
     switch (this.notification.api) {
     case NotificationAPI.PINGIE_NOTIFY:
-      await this.pingieNotify(resetting);
+      await this.pingieNotify(type);
       break;
     case NotificationAPI.PUSHOVER:
-      await this.pushover(resetting);
+      await this.pushover(type);
       break;
     }
   }
 
-  private async pingieNotify(resetting: boolean) {
+  private async pingieNotify(type: NotificationType) {
     try {
 
       const endpoint = `https://notifypush.pingie.com/notify-json/${this.notification.id}`;
 
       const payload: Record<string, string | undefined> = {
-        text: (resetting && this.notification?.onReset) ? this.notification.resetText : this.notification.text,
-        title: (resetting && this.notification?.onReset) ? this.notification.resetTitle : this.notification.title,
+        text: type === NotificationType.RESET ? this.notification.resetText : this.notification.text,
+        title: type === NotificationType.RESET ? this.notification.resetTitle : this.notification.title,
         groupType: this.notification.groupType,
         iconUrl: this.notification.iconURL ?? DEFAULT_PUSH_ICON_URL,
       };
@@ -100,7 +115,7 @@ export class NotificationManager {
     }
   }
 
-  private async pushover(resetting: boolean) {
+  private async pushover(type: NotificationType) {
 
     const key = Buffer.from(PLUGIN_NAME, 'utf8');
     const bytes = [...P2, ...P3, ...P1];
@@ -113,8 +128,8 @@ export class NotificationManager {
       const params: Record<string, string | undefined> = {
         token,
         user: this.notification.token,
-        message: (resetting && this.notification?.onReset) ? this.notification.resetText : this.notification.text,
-        title: (resetting && this.notification?.onReset) ? this.notification.resetTitle : this.notification.title,
+        message: type === NotificationType.RESET ? this.notification.resetText : this.notification.text,
+        title: type === NotificationType.RESET ? this.notification.resetTitle : this.notification.title,
       };
 
       const response = await axios.post(endpoint, undefined,

--- a/src/model/types.ts
+++ b/src/model/types.ts
@@ -82,11 +82,10 @@ export type Notification = Assertable & {
   id: string,
   title?: string,
   text: string,
-  groupType?: string,
-  iconURL?: string,
-  onReset?: boolean,
   resetTitle?: string,
   resetText?: string,
+  groupType?: string,
+  iconURL?: string,
 }
 
 export type LimiterConfig = Assertable & {

--- a/src/model/types.ts
+++ b/src/model/types.ts
@@ -84,6 +84,9 @@ export type Notification = Assertable & {
   text: string,
   groupType?: string,
   iconURL?: string,
+  onReset?: boolean,
+  resetTitle?: string,
+  resetText?: string,
 }
 
 export type LimiterConfig = Assertable & {

--- a/src/model/types.ts
+++ b/src/model/types.ts
@@ -81,7 +81,7 @@ export type Notification = Assertable & {
   token: string,
   id: string,
   title?: string,
-  text: string,
+  text?: string,
   resetTitle?: string,
   resetText?: string,
   groupType?: string,


### PR DESCRIPTION
Offering up this PR that adds a user option to send a notification when an accessory resets in addition to existing function that sends when triggered.  Adds a checkbox to the user interface which if enabled then shows new entry fields for a title and text message... so the user can have unique messages depending on triggered/reset state.

I have tested this with an Outlet and a Lighbulb (with and without brightness control) and it is working as expected... observing that when adjusting brightness you get a notification when lightbulb moves from off state to any brightness... no notification while it is on but adjusting brightness, and then a notification (if requested) when brightness goes all way down to zero.

I have not updated CHANGELOG.md, I leave that to you with whatever else goes into next release.

The Wiki should be updated as well.  I would add a statrement about the "Reset on Restart" option... if this is NOT selected then your WILL get a notification when the plugin bridge is restarted.  Selecting the option prevents that notification.  Note, this PR has nothing to do with that, I just observe this behaviour.

Also... I do not agree with statement in Wiki and changelog that _Monthly Pushover notification limits are shared across all Dummy users_.  I do not know how that can be true as each user has their own monthly allocation.  In my case I have a 10,000 notifications a month on their "free" account (well, there is a one-time lifetime fee of $5 per platform), but those 10,000 are all mine, no sharing with any other Pushover (or dummy plugin) user.