### PR TITLE
Handle missing stdout from successful commands

### DIFF
--- a/src/accessory/base.ts
+++ b/src/accessory/base.ts
@@ -371,7 +371,7 @@ export abstract class DummyAccessory<C extends DummyConfig> implements MatterAcc
 
     try {
       const { stdout } = await this.execAsync(command, execOptions);
-      const output = stdout.trim();
+      const output = (stdout ?? '').trim();
 
       if (output !== undefined) {
         this.logIfDesired(`${strings.command.executed}: %s\n%s`, command, output);


### PR DESCRIPTION
## Summary
- treat missing command stdout as an empty string before trimming
- prevent successful command execution from being reported as an unexpected TypeError

## Validation
- npm run build
- npm run lint

Observed with homebridge-dummy 2.0.0 on Windows and Node 22, where a successful command callback can provide undefined stdout.